### PR TITLE
Move dotenv to scripts for pm2 deployment

### DIFF
--- a/igo-marketplace-login-backend/app.js
+++ b/igo-marketplace-login-backend/app.js
@@ -1,7 +1,6 @@
 const express = require("express");
 const path = require("path");
 const cookieParser = require("cookie-parser");
-require("dotenv").config();
 const indexRouter = require("./routes/index");
 const apiRouter = require("./routes/api");
 const apiResponse = require("./helpers/apiResponse");

--- a/igo-marketplace-login-backend/package.json
+++ b/igo-marketplace-login-backend/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "start": "node ./bin/www",
-    "dev": "nodemon ./bin/www",
+    "start": "node -r dotenv/config ./bin/www",
+    "dev": "nodemon -r dotenv/config  ./bin/www",
     "config-qa": "cp services/qa.config.js services/config.js",
     "test": "JWT_SECRET={ADD_JWT_SECRET} nyc _mocha --timeout 10000 --exit --report lcovonly -- -R spec",
     "lint": "eslint --fix --config .eslintrc.json \"**/*.js\""


### PR DESCRIPTION
This change allows pm2 managed apps to have separate env variables. Also, dotenv recommends it: https://github.com/motdotla/dotenv#preload