### PR TITLE
handling ldap reconnect

### DIFF
--- a/igo-marketplace-login-backend/controllers/AuthController.js
+++ b/igo-marketplace-login-backend/controllers/AuthController.js
@@ -23,6 +23,10 @@ const client = ldap.createClient({
 		rejectUnauthorized: false
 	}
 });
+// REF - https://github.com/ldapjs/node-ldapjs/issues/318#issuecomment-165769581
+client.on('error', function(err) {
+    console.warn('LDAP connection failed, but fear not, it will reconnect OK', err);
+});
 
 const sendLDAPSearch = async function(client, user) {
 	const opts = {


### PR DESCRIPTION
**Description**: LDAP library automatically disconnects and throws an error (below). This error needs to be caught or the application will restart.
**Fix**: Wrap the return of `ldap.createClient` w/ error handling

```
events.js:177
      throw er; // Unhandled 'error' event
      ^

Error: read ECONNRESET
    at TLSWrap.onStreamRead (internal/stream_base_commons.js:183:27)
Emitted 'error' event at:
    at TLSSocket.onSocketError (/Users/patrunoa/workspace/igo-marketplace-login/igo-marketplace-login-backend/node_modules/ldapjs/lib/client/client.js:1169:12)
    at TLSSocket.emit (events.js:200:13)I7_Index_ID
    at emitErrorNT (internal/streams/destroy.js:91:8)
    at emitErrorAndCloseNT (internal/streams/destroy.js:59:3)
    at processTicksAndRejections (internal/process/task_queues.js:84:9) {
  errno: 'ECONNRESET',
  code: 'ECONNRESET',
  syscall: 'read'
}
[nodemon] app crashed - waiting for file changes before starting...
```
**Testing**:
```
$ pm2 ls
┌─────┬────────────────────┬─────────────┬─────────┬─────────┬──────────┬────────┬──────┬───────────┬──────────┬──────────┬──────────┬──────────┐
│ id  │ name               │ namespace   │ version │ mode    │ pid      │ uptime │ ↺    │ status    │ cpu      │ mem      │ user     │ watching │
├─────┼────────────────────┼─────────────┼─────────┼─────────┼──────────┼────────┼──────┼───────────┼──────────┼──────────┼──────────┼──────────┤
...
│ 29  │ login              │ default     │ 1.0.0   │ fork    │ 13241    │ 3m     │ 0    │ online    │ 0%       │ 1.2mb    │ root     │ disabled │
...
└─────┴────────────────────┴─────────────┴─────────┴─────────┴──────────┴────────┴──────┴───────────┴──────────┴──────────┴──────────┴──────────┘
[PM2][WARN]
```