### PR TITLE
adding reconnect = true

### DIFF
--- a/igo-marketplace-login-backend/controllers/AuthController.js
+++ b/igo-marketplace-login-backend/controllers/AuthController.js
@@ -18,10 +18,11 @@ const {
 
 const client = ldap.createClient({
 	url: 'ldaps://mskcc.root.mskcc.org/', // Error: connect ECONNREFUSED 23.202.231.169:636
-	// url: 'ldaps://ldapha.mskcc.root.mskcc.org/'	// Error: getaddrinfo ENOTFOUND ldapha.mskcc.root.mskcc.org
+	// url: 'ldaps://ldapha.mskcc.root.mskcc.org/',	// Error: getaddrinfo ENOTFOUND ldapha.mskcc.root.mskcc.org
 	tlsOptions: {
 		rejectUnauthorized: false
-	}
+	},
+    reconnect: true
 });
 // REF - https://github.com/ldapjs/node-ldapjs/issues/318#issuecomment-165769581
 client.on('error', function(err) {


### PR DESCRIPTION
If reconnect isn't true, the ldap client will catch the error, but not restart

```
$ dzdo pm2 ls
[dzdo] password for streidd:
┌─────┬────────────────────┬─────────────┬─────────┬─────────┬──────────┬────────┬──────┬───────────┬──────────┬──────────┬──────────┬──────────┐
│ id  │ name               │ namespace   │ version │ mode    │ pid      │ uptime │ ↺    │ status    │ cpu      │ mem      │ user     │ watching │
├─────┼────────────────────┼─────────────┼─────────┼─────────┼──────────┼────────┼──────┼───────────┼──────────┼──────────┼──────────┼──────────┤
...
│ 41  │ login              │ default     │ N/A     │ fork    │ 13289    │ 3D     │ 0    │ online    │ 0.4%     │ 32.1mb   │ root     │ disabled │
...
```